### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/authenticationService.yml
+++ b/.github/workflows/authenticationService.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: joegoslavie/kwetter-authenticationservice
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/followingService.yml
+++ b/.github/workflows/followingService.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: joegoslavie/kwetter-followingservice
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/profileService.yml
+++ b/.github/workflows/profileService.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: joegoslavie/kwetter-profileservice
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/tweetService.yml
+++ b/.github/workflows/tweetService.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: joegoslavie/kwetter-tweetservice
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore